### PR TITLE
Invalid defaultParameter

### DIFF
--- a/ControlePluvial/App_Start/RouteConfig.cs
+++ b/ControlePluvial/App_Start/RouteConfig.cs
@@ -12,7 +12,7 @@ namespace ControlePluvial
             routes.MapRoute(
                 name: "Default",
                 url: "API/{controller}/{action}",
-                defaults: new { controller = "Home", action = "Index", id = UrlParameter.Optional }
+                defaults: new { controller = "Home", action = "Index"}
             );
             routes.MapRoute(
                name: "spa-fallback",


### PR DESCRIPTION
Id is not needed and can be removed, you don't have references for ID property on URL Input of MapRoute